### PR TITLE
feat: add count endpoint and fix genially helper method

### DIFF
--- a/src/api/controllers/genially/Count.ts
+++ b/src/api/controllers/genially/Count.ts
@@ -1,0 +1,11 @@
+import { Request, Response } from "express";
+import CountGeniallyService from "../../../contexts/core/genially/application/CountGeniallyService";
+import { repository } from "../../app";
+
+export const countGenially = async (req: Request, res: Response) => {
+  const service = new CountGeniallyService(repository);
+  const count = await service.execute();
+
+  res.status(200).json({ count });
+};
+

--- a/src/api/controllers/genially/Router.ts
+++ b/src/api/controllers/genially/Router.ts
@@ -4,11 +4,13 @@ import { getGenially } from "./Get";
 import { deleteGenially } from "./Delete";
 import { findGenially } from "./Find";
 import { renameGenially } from "./Rename";
+import { countGenially } from "./Count";
 
 export const router = express.Router();
 
-router.get("/genially", getGenially);
-router.post("/genially", createGenially);
+router.get("/genially/count", countGenially);
 router.get("/genially/:id", findGenially);
 router.delete("/genially/:id", deleteGenially);
 router.patch("/genially/:id", renameGenially);
+router.get("/genially", getGenially);
+router.post("/genially", createGenially);

--- a/src/contexts/core/genially/application/CountGeniallyService.ts
+++ b/src/contexts/core/genially/application/CountGeniallyService.ts
@@ -1,0 +1,10 @@
+import GeniallyRepository from "../domain/GeniallyRepository";
+
+export default class CountGeniallyService {
+  constructor(private repository: GeniallyRepository) {}
+
+  public async execute(): Promise<number> {
+    const geniallies = await this.repository.findAll();
+    return geniallies.length;
+  }
+}

--- a/src/contexts/core/genially/application/CountGeniallyService.ts
+++ b/src/contexts/core/genially/application/CountGeniallyService.ts
@@ -4,7 +4,6 @@ export default class CountGeniallyService {
   constructor(private repository: GeniallyRepository) {}
 
   public async execute(): Promise<number> {
-    const geniallies = await this.repository.findAll();
-    return geniallies.length;
+    return await this.repository.count();
   }
 }

--- a/src/contexts/core/genially/domain/GeniallyRepository.ts
+++ b/src/contexts/core/genially/domain/GeniallyRepository.ts
@@ -1,6 +1,8 @@
 import Genially from "./Genially";
 
 interface GeniallyRepository {
+  count(): Promise<number>;
+
   save(genially: Genially): Promise<void>;
 
   find(id: string): Promise<Genially>;

--- a/src/contexts/core/genially/infrastructure/InMemoryGeniallyRepository.ts
+++ b/src/contexts/core/genially/infrastructure/InMemoryGeniallyRepository.ts
@@ -4,6 +4,10 @@ import GeniallyRepository from "../domain/GeniallyRepository";
 export default class InMemoryGeniallyRepository implements GeniallyRepository {
   private geniallys: Genially[] = [];
 
+  async count(): Promise<number> {
+    return this.geniallys.length;
+  }
+
   async save(genially: Genially): Promise<void> {
     await this.delete(genially.id);
     this.geniallys.push(genially);

--- a/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
+++ b/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
@@ -4,6 +4,10 @@ import { GeniallySchema } from "../domain/GeniallySchema";
 
 export default class MongoGeniallyRepository implements GeniallyRepository {
 
+  async count(): Promise<number> {
+    return await GeniallySchema.count();
+  }
+
   async save(genially: Genially): Promise<void> {
     await this.delete(genially.id);
 

--- a/test/api/controllers/genially/Count.test.ts
+++ b/test/api/controllers/genially/Count.test.ts
@@ -1,0 +1,37 @@
+import request from "supertest";
+import app from "../../../../src/api/app";
+import { createGenially } from "../../../utils/createGenially";
+
+describe("CountController", () => {
+  it("should return the number of Geniallys", async () => {
+    const geniallys = createGenially(3);
+
+    await request(app)
+      .post("/api/genially")
+      .send(geniallys[0])
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(201);
+
+    await request(app)
+      .post("/api/genially")
+      .send(geniallys[1])
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(201);
+
+    await request(app)
+      .post("/api/genially")
+      .send(geniallys[2])
+      .set("Accept", "application/json")
+      .expect("Content-Type", /json/)
+      .expect(201);
+
+
+    const response = await request(app)
+      .get("/api/genially/count")
+      .set("Accept", "application/json");
+
+    expect(response.body.count).toBe(3);
+  });
+});

--- a/test/utils/createGenially.ts
+++ b/test/utils/createGenially.ts
@@ -3,12 +3,12 @@ import faker from "@faker-js/faker";
 import { CreateGeniallyServiceRequest } from "../../src/contexts/core/genially/domain/GeniallyRequest";
 
 export const createGenially = (length = 1): CreateGeniallyServiceRequest[] => {
-  return Array.from<CreateGeniallyServiceRequest>({ length}).fill(
-    {
+  return Array.from<CreateGeniallyServiceRequest>({ length}).fill(undefined).map(() =>
+    ({
       id: faker.datatype.uuid(),
       name: faker.name.firstName(),
       description: faker.lorem.words(125)
-    }
+    })
   );
 };
 


### PR DESCRIPTION
# Description

This pull request adds the following features:

- **Count the number of geniallys created**: For internal analytics, we want to know the number of geniallys that are created in our platform. When a new genially is created, this counter is increased. But if a genially is deleted, this counter should not be decreased.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Everything is covered by test: 

![image](https://user-images.githubusercontent.com/3502075/153143604-a20be084-2fb3-40dd-a3cc-50c8d7968489.png)

![image](https://user-images.githubusercontent.com/3502075/153143628-bffaa198-68db-412a-aed6-91bf36ebe8b3.png)

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules