### PR TITLE
feat: add persistence

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM node:16
+
+WORKDIR /usr/src/app
+
+COPY . .
+
+RUN npm install
+
+RUN npm run build
+
+CMD [ "npm", "run", "serve" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+
+version: '3'
+services:
+  node:
+    restart: always
+    build: .
+    ports:
+      - 3000:3000
+    volumes:
+      - ./:/code
+  mongo:
+    image: mongo
+    ports:
+      - 27017:27017
+    volumes:
+      - mongodb:/data/db
+volumes:
+ mongodb:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1071,8 +1071,7 @@
     "@types/node": {
       "version": "13.13.4",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-13.13.4.tgz",
-      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA==",
-      "dev": true
+      "integrity": "sha512-x26ur3dSXgv5AwKS0lNfbjpCakGIduWU1DU91Zz58ONRWrIKGunmZBNv4P7N+e27sJkiGDsw/3fT4AtsqQBrBA=="
     },
     "@types/normalize-package-data": {
       "version": "2.4.0",
@@ -1143,6 +1142,20 @@
       "dev": true,
       "requires": {
         "@types/superagent": "*"
+      }
+    },
+    "@types/webidl-conversions": {
+      "version": "6.1.1",
+      "resolved": "https://registry.npmjs.org/@types/webidl-conversions/-/webidl-conversions-6.1.1.tgz",
+      "integrity": "sha512-XAahCdThVuCFDQLT7R7Pk/vqeObFNL3YqRyFZg+AqAP/W1/w3xHaIxuW7WszQqTbIBOPRcItYJIou3i/mppu3Q=="
+    },
+    "@types/whatwg-url": {
+      "version": "8.2.1",
+      "resolved": "https://registry.npmjs.org/@types/whatwg-url/-/whatwg-url-8.2.1.tgz",
+      "integrity": "sha512-2YubE1sjj5ifxievI5Ge1sckb9k/Er66HyR2c+3+I6VDUUg1TLPdYYTEbQ+DjRkS4nTxMJhgWfSfMRD2sl2EYQ==",
+      "requires": {
+        "@types/node": "*",
+        "@types/webidl-conversions": "*"
       }
     },
     "@types/yargs": {
@@ -1654,6 +1667,11 @@
         }
       }
     },
+    "base64-js": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/base64-js/-/base64-js-1.5.1.tgz",
+      "integrity": "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="
+    },
     "bcrypt-pbkdf": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
@@ -1743,6 +1761,23 @@
       "dev": true,
       "requires": {
         "node-int64": "^0.4.0"
+      }
+    },
+    "bson": {
+      "version": "4.6.1",
+      "resolved": "https://registry.npmjs.org/bson/-/bson-4.6.1.tgz",
+      "integrity": "sha512-I1LQ7Hz5zgwR4QquilLNZwbhPw0Apx7i7X9kGMBTsqPdml/03Q9NBtD9nt/19ahjlphktQImrnderxqpzeVDjw==",
+      "requires": {
+        "buffer": "^5.6.0"
+      }
+    },
+    "buffer": {
+      "version": "5.7.1",
+      "resolved": "https://registry.npmjs.org/buffer/-/buffer-5.7.1.tgz",
+      "integrity": "sha512-EHcyIPBQ4BSGlvjB16k5KgAJ27CIsHY/2JBmCRReo48y9rQ3MaUzWX3KVlBa4U7MyX02HdVj0K7C3WaB3ju7FQ==",
+      "requires": {
+        "base64-js": "^1.3.1",
+        "ieee754": "^1.1.13"
       }
     },
     "buffer-from": {
@@ -2361,6 +2396,11 @@
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha1-3zrhmayt+31ECqrgsp4icrJOxhk=",
       "dev": true
+    },
+    "denque": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/denque/-/denque-2.0.1.tgz",
+      "integrity": "sha512-tfiWc6BQLXNLpNiR5iGd0Ocu3P3VpxfzFiqubLgMfhfOw9WyvgJBd46CClNn9k3qfbjvT//0cf7AlYRX/OslMQ=="
     },
     "depd": {
       "version": "1.1.2",
@@ -3440,6 +3480,11 @@
         "safer-buffer": ">= 2.1.2 < 3"
       }
     },
+    "ieee754": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/ieee754/-/ieee754-1.2.1.tgz",
+      "integrity": "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="
+    },
     "ignore": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-4.0.6.tgz",
@@ -3542,6 +3587,11 @@
         "strip-ansi": "^6.0.0",
         "through": "^2.3.6"
       }
+    },
+    "ip": {
+      "version": "1.1.5",
+      "resolved": "https://registry.npmjs.org/ip/-/ip-1.1.5.tgz",
+      "integrity": "sha1-vd7XARQpCCjAoDnnLvJfWq7ENUo="
     },
     "ip-regex": {
       "version": "2.1.0",
@@ -5124,6 +5174,11 @@
         "verror": "1.10.0"
       }
     },
+    "kareem": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/kareem/-/kareem-2.3.3.tgz",
+      "integrity": "sha512-uESCXM2KdtOQ8LOvKyTUXEeg0MkYp4wGglTIpGcYHvjJcS5sn2Wkfrfit8m4xSbaNDAw2KdI9elgkOxZbrFYbg=="
+    },
     "keyv": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-3.1.0.tgz",
@@ -5316,6 +5371,12 @@
       "resolved": "https://registry.npmjs.org/media-typer/-/media-typer-0.3.0.tgz",
       "integrity": "sha1-hxDXrwqmJvj/+hzgAWhUUmMlV0g="
     },
+    "memory-pager": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/memory-pager/-/memory-pager-1.5.0.tgz",
+      "integrity": "sha512-ZS4Bp4r/Zoeq6+NLJpP+0Zzm0pR8whtGPf1XExKLJBAczGMnSi3It14OiNCStjQjM6NU1okjQGSxgEZN8eBYKg==",
+      "optional": true
+    },
     "meow": {
       "version": "3.7.0",
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
@@ -5475,6 +5536,100 @@
       "dev": true,
       "requires": {
         "minimist": "^1.2.5"
+      }
+    },
+    "mongodb": {
+      "version": "4.3.1",
+      "resolved": "https://registry.npmjs.org/mongodb/-/mongodb-4.3.1.tgz",
+      "integrity": "sha512-sNa8APSIk+r4x31ZwctKjuPSaeKuvUeNb/fu/3B6dRM02HpEgig7hTHM8A/PJQTlxuC/KFWlDlQjhsk/S43tBg==",
+      "requires": {
+        "bson": "^4.6.1",
+        "denque": "^2.0.1",
+        "mongodb-connection-string-url": "^2.4.1",
+        "saslprep": "^1.0.3",
+        "socks": "^2.6.1"
+      }
+    },
+    "mongodb-connection-string-url": {
+      "version": "2.4.2",
+      "resolved": "https://registry.npmjs.org/mongodb-connection-string-url/-/mongodb-connection-string-url-2.4.2.tgz",
+      "integrity": "sha512-mZUXF6nUzRWk5J3h41MsPv13ukWlH4jOMSk6astVeoZ1EbdTJyF5I3wxKkvqBAOoVtzLgyEYUvDjrGdcPlKjAw==",
+      "requires": {
+        "@types/whatwg-url": "^8.2.1",
+        "whatwg-url": "^11.0.0"
+      },
+      "dependencies": {
+        "tr46": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/tr46/-/tr46-3.0.0.tgz",
+          "integrity": "sha512-l7FvfAHlcmulp8kr+flpQZmVwtu7nfRV7NZujtN0OqES8EL4O4e0qqzL0DC5gAvx/ZC/9lk6rhcUwYvkBnBnYA==",
+          "requires": {
+            "punycode": "^2.1.1"
+          }
+        },
+        "webidl-conversions": {
+          "version": "7.0.0",
+          "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+          "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g=="
+        },
+        "whatwg-url": {
+          "version": "11.0.0",
+          "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-11.0.0.tgz",
+          "integrity": "sha512-RKT8HExMpoYx4igMiVMY83lN6UeITKJlBQ+vR/8ZJ8OCdSiN3RwCq+9gH0+Xzj0+5IrM6i4j/6LuvzbZIQgEcQ==",
+          "requires": {
+            "tr46": "^3.0.0",
+            "webidl-conversions": "^7.0.0"
+          }
+        }
+      }
+    },
+    "mongoose": {
+      "version": "6.2.1",
+      "resolved": "https://registry.npmjs.org/mongoose/-/mongoose-6.2.1.tgz",
+      "integrity": "sha512-VxY1wvlc4uBQKyKNVDoEkTU3/ayFOD//qVXYP+sFyvTRbAj9/M53UWTERd84pWogs2TqAC6DTvZbxCs2LoOd3Q==",
+      "requires": {
+        "bson": "^4.2.2",
+        "kareem": "2.3.3",
+        "mongodb": "4.3.1",
+        "mpath": "0.8.4",
+        "mquery": "4.0.2",
+        "ms": "2.1.2",
+        "sift": "13.5.2"
+      },
+      "dependencies": {
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
+      }
+    },
+    "mpath": {
+      "version": "0.8.4",
+      "resolved": "https://registry.npmjs.org/mpath/-/mpath-0.8.4.tgz",
+      "integrity": "sha512-DTxNZomBcTWlrMW76jy1wvV37X/cNNxPW1y2Jzd4DZkAaC5ZGsm8bfGfNOthcDuRJujXLqiuS6o3Tpy0JEoh7g=="
+    },
+    "mquery": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/mquery/-/mquery-4.0.2.tgz",
+      "integrity": "sha512-oAVF0Nil1mT3rxty6Zln4YiD6x6QsUWYz927jZzjMxOK2aqmhEz5JQ7xmrKK7xRFA2dwV+YaOpKU/S+vfNqKxA==",
+      "requires": {
+        "debug": "4.x"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "4.3.3",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.3.tgz",
+          "integrity": "sha512-/zxw5+vh1Tfv+4Qn7a5nsbcJKPaSvCDhojn6FEl9vupwK2VCSDtEiEtqr8DFtzYFOdz63LBkxec7DYuc2jon6Q==",
+          "requires": {
+            "ms": "2.1.2"
+          }
+        },
+        "ms": {
+          "version": "2.1.2",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
+          "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w=="
+        }
       }
     },
     "ms": {
@@ -6055,8 +6210,7 @@
     "punycode": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-2.1.1.tgz",
-      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==",
-      "dev": true
+      "integrity": "sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A=="
     },
     "pupa": {
       "version": "2.0.1",
@@ -6573,6 +6727,15 @@
         }
       }
     },
+    "saslprep": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/saslprep/-/saslprep-1.0.3.tgz",
+      "integrity": "sha512-/MY/PEMbk2SuY5sScONwhUDsV2p77Znkb/q3nSVstq/yQzYJOH/Azh29p9oJLsl3LnQwSvZDKagDGBsBwSooag==",
+      "optional": true,
+      "requires": {
+        "sparse-bitfield": "^3.0.3"
+      }
+    },
     "saxes": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/saxes/-/saxes-5.0.1.tgz",
@@ -6690,6 +6853,11 @@
       "integrity": "sha512-vFwSUfQvqybiICwZY5+DAWIPLKsWO31Q91JSKl3UYv+K5c2QRPzn0qzec6QPu1Qc9eHYItiP3NdJqNVqetYAww==",
       "dev": true
     },
+    "sift": {
+      "version": "13.5.2",
+      "resolved": "https://registry.npmjs.org/sift/-/sift-13.5.2.tgz",
+      "integrity": "sha512-+gxdEOMA2J+AI+fVsCqeNn7Tgx3M9ZN9jdi95939l1IJ8cZsqS8sqpJyOkic2SJk+1+98Uwryt/gL6XDaV+UZA=="
+    },
     "signal-exit": {
       "version": "3.0.3",
       "resolved": "https://registry.npmjs.org/signal-exit/-/signal-exit-3.0.3.tgz",
@@ -6750,6 +6918,11 @@
           "dev": true
         }
       }
+    },
+    "smart-buffer": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/smart-buffer/-/smart-buffer-4.2.0.tgz",
+      "integrity": "sha512-94hK0Hh8rPqQl2xXc3HsaBoOXKV20MToPkcXvwbISWLEs+64sBq5kFgn2kJDHb1Pry9yrP0dxrCI9RRci7RXKg=="
     },
     "snapdragon": {
       "version": "0.8.2",
@@ -6864,6 +7037,15 @@
         }
       }
     },
+    "socks": {
+      "version": "2.6.2",
+      "resolved": "https://registry.npmjs.org/socks/-/socks-2.6.2.tgz",
+      "integrity": "sha512-zDZhHhZRY9PxRruRMR7kMhnf3I8hDs4S3f9RecfnGxvcBHQcKcIH/oUcEWffsfl1XxdYlA7nnlGbbTvPz9D8gA==",
+      "requires": {
+        "ip": "^1.1.5",
+        "smart-buffer": "^4.2.0"
+      }
+    },
     "source-map": {
       "version": "0.6.1",
       "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
@@ -6898,6 +7080,15 @@
       "resolved": "https://registry.npmjs.org/source-map-url/-/source-map-url-0.4.0.tgz",
       "integrity": "sha1-PpNdfd1zYxuXZZlW1VEo6HtQhKM=",
       "dev": true
+    },
+    "sparse-bitfield": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/sparse-bitfield/-/sparse-bitfield-3.0.3.tgz",
+      "integrity": "sha1-/0rm5oZWBWuks+eSqzM004JzyhE=",
+      "optional": true,
+      "requires": {
+        "memory-pager": "^1.0.2"
+      }
     },
     "spdx-correct": {
       "version": "3.1.0",

--- a/package.json
+++ b/package.json
@@ -19,7 +19,8 @@
     "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "express": "^4.17.1",
-    "lusca": "^1.6.1"
+    "lusca": "^1.6.1",
+    "mongoose": "^6.2.1"
   },
   "devDependencies": {
     "@faker-js/faker": "^6.0.0-alpha.5",

--- a/package.json
+++ b/package.json
@@ -7,12 +7,12 @@
     "build": "npm run build-ts && npm run lint",
     "dev": "cross-env NODE_ENV=dev ts-node-dev --ignore-watch node_modules --inspect=0.0.0.0:9267 ./src/api/server.ts",
     "lint": "tsc --noEmit && eslint \"**/*.{js,ts}\" --quiet --fix",
-    "serve-debug": "nodemon --inspect dist/server.js",
-    "serve": "node dist/server.js",
-    "start": "npm run serve",
+    "serve-debug": "nodemon --inspect dist/api/server.js",
+    "serve": "ENVIRONMENT=prod node dist/api/server.js",
+    "start": "ENVIRONMENT=test npm run serve",
     "test": "jest --forceExit --coverage --verbose",
-    "watch-node": "nodemon dist/server.js",
-    "watch-test": "npm run test -- --watchAll",
+    "watch-node": "ENVIRONMENT=test nodemon dist/api/server.js",
+    "watch-test": "ENVIRONMENT=test npm run test -- --watchAll",
     "watch-ts": "tsc -w"
   },
   "dependencies": {

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,11 +1,12 @@
 import compression from "compression";
 import express from "express";
 import lusca from "lusca";
-import { router } from "./controllers/Genially/Router";
+import { router } from "./controllers/genially/Router";
 import InMemoryGeniallyRepository from "../contexts/core/genially/infrastructure/InMemoryGeniallyRepository";
 
 // Controllers (route handlers)
 import * as healthController from "./controllers/health";
+import MongoGeniallyRepository from "../contexts/core/genially/infrastructure/MongoGeniallyRepository";
 
 // Create Express server
 const app = express();
@@ -23,4 +24,6 @@ app.use("/api", router);
 app.get("/", healthController.check);
 
 export default app;
-export const repository = new InMemoryGeniallyRepository();
+export const repository = process.env.ENVIRONMENT === "test"
+  ? new InMemoryGeniallyRepository()
+  : new MongoGeniallyRepository;

--- a/src/api/app.ts
+++ b/src/api/app.ts
@@ -1,6 +1,7 @@
 import compression from "compression";
 import express from "express";
 import lusca from "lusca";
+import mongoose from "mongoose";
 import { router } from "./controllers/genially/Router";
 import InMemoryGeniallyRepository from "../contexts/core/genially/infrastructure/InMemoryGeniallyRepository";
 
@@ -24,6 +25,13 @@ app.use("/api", router);
 app.get("/", healthController.check);
 
 export default app;
+
+async function connect() {
+  await mongoose.connect("mongodb://mongo:27017/documents");
+}
+
+if(process.env.ENVIRONMENT === "prod") connect();
+
 export const repository = process.env.ENVIRONMENT === "test"
   ? new InMemoryGeniallyRepository()
   : new MongoGeniallyRepository;

--- a/src/contexts/core/genially/domain/GeniallySchema.ts
+++ b/src/contexts/core/genially/domain/GeniallySchema.ts
@@ -1,0 +1,9 @@
+import mongoose from "mongoose";
+
+const geniallySchema = new mongoose.Schema({
+  id: String,
+  name: String,
+  description: String
+});
+
+export const GeniallySchema = mongoose.model("Genially", geniallySchema);

--- a/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
+++ b/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
@@ -1,0 +1,20 @@
+import Genially from "../domain/Genially";
+import GeniallyRepository from "../domain/GeniallyRepository";
+
+export default class MongoGeniallyRepository implements GeniallyRepository {
+  async save(genially: Genially): Promise<void> {
+    await this.delete(genially.id);
+  }
+
+  async find(id: string): Promise<Genially> {
+    return new Promise(res => res({id} as Genially));
+  }
+
+  async findAll(): Promise<Genially[]> {
+    return new Promise(res => res([] as Genially[]));
+  }
+
+  async delete(id: string): Promise<void> {
+    new Promise(res => res({id}));
+  }
+}

--- a/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
+++ b/src/contexts/core/genially/infrastructure/MongoGeniallyRepository.ts
@@ -1,20 +1,34 @@
 import Genially from "../domain/Genially";
 import GeniallyRepository from "../domain/GeniallyRepository";
+import { GeniallySchema } from "../domain/GeniallySchema";
 
 export default class MongoGeniallyRepository implements GeniallyRepository {
+
   async save(genially: Genially): Promise<void> {
     await this.delete(genially.id);
+
+    const newGenially = new GeniallySchema();
+    newGenially.id = genially.id;
+    newGenially.name = genially.name;
+    newGenially.description = genially.description;
+
+    await newGenially.save();
   }
 
   async find(id: string): Promise<Genially> {
-    return new Promise(res => res({id} as Genially));
+    return await GeniallySchema.findById(id);
   }
 
   async findAll(): Promise<Genially[]> {
-    return new Promise(res => res([] as Genially[]));
+    const geniallys = await GeniallySchema.find<Genially>();
+    return geniallys.map(g => ({
+      id: g.id,
+      name: g.name,
+      description: g.description
+    } as Genially));
   }
 
   async delete(id: string): Promise<void> {
-    new Promise(res => res({id}));
+    await GeniallySchema.deleteOne( { id });
   }
 }


### PR DESCRIPTION
# Description

This pull request adds the following features:

- Provide an **alternative implementation of GeniallyRepository in order to communicate with a Mongo database**. This implementation should be interchangeable with the provided InMemoryGeniallyRepository.

## Type of change

Please delete options that are not relevant.
- [X] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Everything is covered by test: 
In order to test the persistence run the following command:

`docker-compose up`

Then you can use the API to add/delete/rename/get.

# Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code
- [X] I have commented my code, particularly in hard-to-understand areas
- [X] I have made corresponding changes to the documentation
- [X] My changes generate no new warnings
- [X] I have added tests that prove my fix is effective or that my feature works
- [X] New and existing unit tests pass locally with my changes
- [X] Any dependent changes have been merged and published in downstream modules